### PR TITLE
Refactor contracts ERC20 e ERC721FullUpgradeable

### DIFF
--- a/contracts/token/ERC20/extensions/TokenageERC20FullUpgradeable.sol
+++ b/contracts/token/ERC20/extensions/TokenageERC20FullUpgradeable.sol
@@ -3,11 +3,9 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "hardhat/console.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
@@ -27,8 +25,6 @@ import "@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol";
  * of the user in these operations.
  */
 abstract contract TokenageERC20FullUpgradeable is
-    Initializable,
-    ERC20Upgradeable,
     PausableUpgradeable,
     AccessControlUpgradeable,
     ERC20BurnableUpgradeable,
@@ -182,29 +178,11 @@ abstract contract TokenageERC20FullUpgradeable is
 
     // The following functions are overrides required by Solidity.
 
-    function _burn(address owner, uint256 amount)
-        internal
-        override(ERC20Upgradeable)
-        whenNotPaused
-    {
-        super._burn(owner, amount);
-    }
-
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        override(AccessControlUpgradeable)
-        returns (bool)
-    {
-        return super.supportsInterface(interfaceId);
-    }
-
     function _authorizeUpgrade(address newImplementation)
         internal
         override
         onlyRole(UPGRADER_ROLE)
     {}
-
 
     /**
      * @dev This empty reserved space is put in place to allow future versions to add new

--- a/contracts/token/ERC721/extensions/TokenageERC721FullUpgradeable.sol
+++ b/contracts/token/ERC721/extensions/TokenageERC721FullUpgradeable.sol
@@ -3,11 +3,9 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "hardhat/console.sol";
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721BurnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
@@ -30,8 +28,6 @@ import "./TokenageERC721PermitUpgradeable.sol";
  * of the user in these operations.
  */
 abstract contract TokenageERC721FullUpgradeable is
-    Initializable,
-    ERC721Upgradeable,
     ERC721EnumerableUpgradeable,
     ERC721URIStorageUpgradeable,
     PausableUpgradeable,
@@ -178,6 +174,10 @@ abstract contract TokenageERC721FullUpgradeable is
         emit TokenMinted(owner, metadataURI, tokenId);
     }
 
+    function _contractNameHash() internal pure virtual returns (bytes32);
+
+    // The following functions are overrides required by Solidity.
+    
     function _beforeTokenTransfer(
         address from,
         address to,
@@ -195,10 +195,6 @@ abstract contract TokenageERC721FullUpgradeable is
         override
         onlyRole(UPGRADER_ROLE)
     {}
-
-    function _contractNameHash() internal pure virtual returns (bytes32);
-
-    // The following functions are overrides required by Solidity.
 
     function _burn(uint256 tokenId)
         internal


### PR DESCRIPTION
#### Changes: 

- Remove `Initializable` from *imports* and **is** declarations;
- Remove `ERC20Upgradeable` from *imports* and **is** declarations;
- Remove `ERC721Upgradeable` from *imports* and **is** declarations;
- Remove unnecessary function overrides from **TokenageERC20FullUpgradeable**

> The abstract contracts above are already inherited by other contracts being used by **TokenageERC20/721FullUpgradeable** contracts.