### PR TITLE
Add IERC165 support

### DIFF
--- a/contracts/mysterybox/ITokenageWhitelist.sol
+++ b/contracts/mysterybox/ITokenageWhitelist.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-interface ITokenageWhitelist {
+import '@openzeppelin/contracts/utils/introspection/ERC165.sol';
+
+interface ITokenageWhitelist is IERC165 {
     event AccountsAdded(uint256 totalAddedAccounts);
     event AccountsRemoved(uint256 totalRemovedAccounts);
 

--- a/contracts/mysterybox/TokenageWhitelist.sol
+++ b/contracts/mysterybox/TokenageWhitelist.sol
@@ -55,4 +55,11 @@ abstract contract TokenageWhitelist is ITokenageWhitelist, DefaultPausable {
     function isOnWhitelist(address addressToCheck) external view override returns (bool) {
         return _whitelistMapping[addressToCheck] == true;
     }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, AccessControl) returns (bool) {
+        return interfaceId == type(ITokenageWhitelist).interfaceId || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/mysterybox/TokenageWhitelistUpgradeable.sol
+++ b/contracts/mysterybox/TokenageWhitelistUpgradeable.sol
@@ -57,4 +57,17 @@ abstract contract TokenageWhitelistUpgradeable is ITokenageWhitelist, DefaultPau
     function isOnWhitelist(address addressToCheck) external view override returns (bool) {
         return _whitelistMapping[addressToCheck] == true;
     }
+
+    /**
+     * @dev See {IERC165-supportsInterface}.
+     */
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(IERC165, AccessControlUpgradeable)
+        returns (bool)
+    {
+        return interfaceId == type(ITokenageWhitelist).interfaceId || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/token/ERC721/extensions/ITokenageMysteryBoxBurnable.sol
+++ b/contracts/token/ERC721/extensions/ITokenageMysteryBoxBurnable.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-interface ITokenageMysteryBoxBurnable {
+import '@openzeppelin/contracts/utils/introspection/ERC165.sol';
+
+interface ITokenageMysteryBoxBurnable is IERC165 {
     event MysteryBoxUserSeedSet(address indexed owner, uint256 tokenId, uint256 userSeed);
 
     function burn(uint256 tokenId) external;

--- a/contracts/token/ERC721/extensions/ITokenageMysteryBoxRevealable.sol
+++ b/contracts/token/ERC721/extensions/ITokenageMysteryBoxRevealable.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
-interface ITokenageMysteryBoxRevealable {
+import '@openzeppelin/contracts/utils/introspection/ERC165.sol';
+
+interface ITokenageMysteryBoxRevealable is IERC165 {
     event MysteryBoxRevealableTokenMinted(address indexed owner, uint256 tokenId, uint16 ticketType);
 
     function mintTo(

--- a/contracts/token/ERC721/extensions/TokenageMysteryBoxBurnableERC721.sol
+++ b/contracts/token/ERC721/extensions/TokenageMysteryBoxBurnableERC721.sol
@@ -89,7 +89,7 @@ abstract contract TokenageMysteryBoxBurnableERC721 is DefaultPausable, ERC721, I
         }
     }
 
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, AccessControl) returns (bool) {
-        return super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC721, AccessControl) returns (bool) {
+        return interfaceId == type(ITokenageMysteryBoxBurnable).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/token/ERC721/extensions/TokenageMysteryBoxBurnableERC721Upgradeable.sol
+++ b/contracts/token/ERC721/extensions/TokenageMysteryBoxBurnableERC721Upgradeable.sol
@@ -96,13 +96,7 @@ abstract contract TokenageMysteryBoxBurnableERC721Upgradeable is
         }
     }
 
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        virtual
-        override(ERC721Upgradeable, AccessControlUpgradeable)
-        returns (bool)
-    {
-        return super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC721Upgradeable, AccessControlUpgradeable) returns (bool) {
+        return interfaceId == type(ITokenageMysteryBoxBurnable).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/token/ERC721/extensions/TokenageMysteryBoxERC721.sol
+++ b/contracts/token/ERC721/extensions/TokenageMysteryBoxERC721.sol
@@ -49,4 +49,8 @@ abstract contract TokenageMysteryBoxERC721 is TokenageMysteryBoxBurnableERC721, 
         uint16 boxType,
         uint64 quantity
     ) internal virtual {}
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, TokenageMysteryBoxBurnableERC721) returns (bool) {
+        return interfaceId == type(ITokenageMysteryBox).interfaceId || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/token/ERC721/extensions/TokenageMysteryBoxERC721Upgradeable.sol
+++ b/contracts/token/ERC721/extensions/TokenageMysteryBoxERC721Upgradeable.sol
@@ -51,4 +51,8 @@ abstract contract TokenageMysteryBoxERC721Upgradeable is TokenageMysteryBoxBurna
         uint16 boxType,
         uint64 quantity
     ) internal virtual {}
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, TokenageMysteryBoxBurnableERC721Upgradeable) returns (bool) {
+        return interfaceId == type(ITokenageMysteryBox).interfaceId || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/token/ERC721/extensions/TokenageMysteryBoxRevealableBurnableERC721.sol
+++ b/contracts/token/ERC721/extensions/TokenageMysteryBoxRevealableBurnableERC721.sol
@@ -58,4 +58,8 @@ abstract contract TokenageMysteryBoxRevealableBurnableERC721 is
     function _setType(uint256 tokenId, uint16 ticketType) internal override {
         super._setType(tokenId, ticketType);
     }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, TokenageMysteryBoxBurnableERC721) returns (bool) {
+        return interfaceId == type(ITokenageMysteryBoxRevealable).interfaceId || super.supportsInterface(interfaceId);
+    }
 }

--- a/contracts/token/ERC721/extensions/TokenageMysteryBoxRevealableERC721.sol
+++ b/contracts/token/ERC721/extensions/TokenageMysteryBoxRevealableERC721.sol
@@ -63,7 +63,7 @@ abstract contract TokenageMysteryBoxRevealableERC721 is DefaultPausable, ERC721,
 
     // The following functions are overrides required by Solidity.
 
-    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC721, AccessControl) returns (bool) {
-        return super.supportsInterface(interfaceId);
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC721, AccessControl) returns (bool) {
+        return interfaceId == type(ITokenageMysteryBoxRevealable).interfaceId || super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/token/ERC721/extensions/TokenageMysteryBoxRevealableERC721Upgradeable.sol
+++ b/contracts/token/ERC721/extensions/TokenageMysteryBoxRevealableERC721Upgradeable.sol
@@ -74,9 +74,9 @@ abstract contract TokenageMysteryBoxRevealableERC721Upgradeable is
         public
         view
         virtual
-        override(ERC721Upgradeable, AccessControlUpgradeable)
+        override(IERC165, ERC721Upgradeable, AccessControlUpgradeable)
         returns (bool)
     {
-        return super.supportsInterface(interfaceId);
+        return interfaceId == type(ITokenageMysteryBoxRevealable).interfaceId || super.supportsInterface(interfaceId);
     }
 }


### PR DESCRIPTION
Add support to `ERC165`, to check if mystery box smart-contracts related implementations are correct (Whitelist, Burnable and Revealable).

Please test with `smart-contracts` PR https://github.com/unfungibleworks/smart-contracts/pull/146.